### PR TITLE
Fix metadata path construction

### DIFF
--- a/src/itchDownloader/downloadGame.ts
+++ b/src/itchDownloader/downloadGame.ts
@@ -77,7 +77,7 @@ export async function downloadGameSingle(params: DownloadGameParams): Promise<Do
          console.log('File renamed successfully to:', finalFilePath);
       }
       metaData = gameProfile?.itchRecord as IItchRecord;
-      metadataPath = downloadDirectory + `\\${gameProfile?.itchRecord?.name}-metadata.json`;
+      metadataPath = path.join(downloadDirectory, `${gameProfile?.itchRecord?.name}-metadata.json`);
 
       if (writeMetaData) {
          await createFile({


### PR DESCRIPTION
## Summary
- use `path.join` to create metadata path in `downloadGame`
- rebuild project

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_686623aa01c48324aee85c602ccbdfc4