### PR TITLE
Add prepublish build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ Contributions are welcome! Please fork the repository and submit pull requests w
 
 Ensure to update tests as appropriate.
 
+When publishing to npm, the `prepublishOnly` script defined in `package.json` automatically runs `npm run build-cli` to build the CLI.
+
 ## License
 
 Distributed under the ISC License.

--- a/package.json
+++ b/package.json
@@ -6,14 +6,15 @@
    "bin": {
       "itchio-downloader": "./dist/cli.js"
    },
-   "scripts": {
-      "clean": "rimraf ./dist/",
-      "build": "npm run clean && tsc",
-      "dev": "nodemon --watch src --ext ts --exec \"ts-node ./src/index.ts\"",
-      "build-cli": "npm run clean && tsc && shx chmod +x ./dist/cli.js",
-      "test:downloadSingle": "npm run build && ts-node ./src/tests/downloadSingle.ts",
-      "test:downloadMultiple": "npm run build && ts-node ./src/tests/downloadMultiple.ts"
-   },
+    "scripts": {
+        "clean": "rimraf ./dist/",
+        "build": "npm run clean && tsc",
+        "dev": "nodemon --watch src --ext ts --exec \"ts-node ./src/index.ts\"",
+        "build-cli": "npm run clean && tsc && shx chmod +x ./dist/cli.js",
+        "prepublishOnly": "npm run build-cli",
+        "test:downloadSingle": "npm run build && ts-node ./src/tests/downloadSingle.ts",
+        "test:downloadMultiple": "npm run build && ts-node ./src/tests/downloadMultiple.ts"
+    },
    "author": "Wal33D",
    "license": "ISC",
    "dependencies": {


### PR DESCRIPTION
## Summary
- run `npm run build-cli` automatically before publishing
- mention the new script in the README

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68662a20a4b083248046b3559dffdfa6