### PR TITLE
Improve waitForFile handling and add tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
         "build-cli": "npm run clean && tsc && shx chmod +x ./dist/cli.js",
         "prepublishOnly": "npm run build-cli",
         "test:downloadSingle": "npm run build && ts-node ./src/tests/downloadSingle.ts",
-        "test:downloadMultiple": "npm run build && ts-node ./src/tests/downloadMultiple.ts"
+        "test:downloadMultiple": "npm run build && ts-node ./src/tests/downloadMultiple.ts",
+        "test:waitForFile": "npm run build && ts-node ./src/tests/waitForFile.test.ts"
     },
    "author": "Wal33D",
    "license": "ISC",

--- a/src/fileUtils/waitForFile.ts
+++ b/src/fileUtils/waitForFile.ts
@@ -11,7 +11,13 @@ const access = util.promisify(fs.access);
  * @param {{ downloadDirectory: string }} params - Object containing the directory to monitor for downloads.
  * @returns {Promise<{status: boolean, message: string, filePath?: string}>} - Resolves with status, message, and the path of the completed file.
  */
-export async function waitForFile({ downloadDirectory }: { downloadDirectory: string }): Promise<{ status: boolean; message: string; filePath?: string }> {
+export async function waitForFile({
+   downloadDirectory,
+   timeoutMs = 30000
+}: {
+   downloadDirectory: string;
+   timeoutMs?: number;
+}): Promise<{ status: boolean; message: string; filePath?: string }> {
    let message = 'Monitoring for file changes...';
 
    // Get initial list of `.crdownload` files to ignore.
@@ -32,6 +38,7 @@ export async function waitForFile({ downloadDirectory }: { downloadDirectory: st
    };
 
    return new Promise<{ status: boolean; message: string; filePath?: string }>((resolve, reject) => {
+      let resolved = false;
       const watcher = fs.watch(downloadDirectory, async (eventType, filename) => {
          if (!filename || filename.endsWith('.temp') || filename.endsWith('.tmp')) return; // Ignore non-files and `.temp` files
 
@@ -50,13 +57,46 @@ export async function waitForFile({ downloadDirectory }: { downloadDirectory: st
                   message = 'Waiting for the final file to appear...';
                }
             } catch (error: any) {
-               watcher.close();
-               reject({ status: false, message: `Error monitoring file: ${error.message}` });
+               if (!resolved) {
+                  resolved = true;
+                  clearTimeout(timer);
+                  watcher.close();
+                  reject({ status: false, message: `Error monitoring file: ${error.message}` });
+               }
             }
          } else if (!initialFiles.has(fullPath) && eventType === 'rename') {
             // Assume the file appearing after a `.crdownload` disappears is the completed file.
+            if (!resolved) {
+               resolved = true;
+               clearTimeout(timer);
+               watcher.close();
+               resolve({ status: true, message: `Download complete: ${filename}`, filePath: fullPath });
+            }
+         }
+      });
+
+      const timer = setTimeout(() => {
+         if (!resolved) {
+            resolved = true;
             watcher.close();
-            resolve({ status: true, message: `Download complete: ${filename}`, filePath: fullPath });
+            resolve({ status: false, message: 'Timed out waiting for download' });
+         }
+      }, timeoutMs);
+
+      watcher.on('error', (error) => {
+         if (!resolved) {
+            resolved = true;
+            clearTimeout(timer);
+            watcher.close();
+            reject({ status: false, message: `Watcher error: ${error.message}` });
+         }
+      });
+
+      watcher.on('close', () => {
+         if (!resolved) {
+            resolved = true;
+            clearTimeout(timer);
+            resolve({ status: false, message: 'File watch terminated before completion' });
          }
       });
    });

--- a/src/tests/waitForFile.test.ts
+++ b/src/tests/waitForFile.test.ts
@@ -1,0 +1,38 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import assert from 'assert';
+import { waitForFile } from '../fileUtils/waitForFile';
+
+async function runTests() {
+  // Success scenario
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wait-file-success-'));
+  const crdownload = path.join(tempDir, 'testfile.crdownload');
+  fs.writeFileSync(crdownload, '');
+
+  setTimeout(() => {
+    fs.renameSync(crdownload, path.join(tempDir, 'testfile.txt'));
+  }, 300);
+
+  const result = await waitForFile({ downloadDirectory: tempDir, timeoutMs: 2000 });
+  assert.strictEqual(result.status, true, 'Expected success status');
+  assert.ok(result.filePath?.endsWith('testfile.txt'), 'Expected final file path');
+  console.log('Success scenario passed');
+
+  // Timeout scenario
+  const tempDirTimeout = fs.mkdtempSync(path.join(os.tmpdir(), 'wait-file-timeout-'));
+  const crdownloadTimeout = path.join(tempDirTimeout, 'fail.crdownload');
+  fs.writeFileSync(crdownloadTimeout, '');
+
+  const start = Date.now();
+  const timeoutResult = await waitForFile({ downloadDirectory: tempDirTimeout, timeoutMs: 1000 });
+  const duration = Date.now() - start;
+  assert.strictEqual(timeoutResult.status, false, 'Expected timeout status');
+  assert.ok(duration >= 1000, 'Should wait at least timeout');
+  console.log('Timeout scenario passed');
+}
+
+runTests().catch(err => {
+  console.error('Tests failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add timeout handling and watcher cleanup in `waitForFile`
- add unit tests demonstrating success and timeout scenarios
- expose new `test:waitForFile` npm script

## Testing
- `npm install`
- `npm run test:waitForFile`


------
https://chatgpt.com/codex/tasks/task_b_68662f65d628832493590d4039893d6b