### PR TITLE
Add Node.js version info

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ I created this tool to build a game launcher/updater for the public/free games t
 
 ## Installation
 
-To install Itchio-Downloader, ensure you have Node.js and npm (or Yarn) installed on your computer. From your terminal, run:
+To install Itchio-Downloader, ensure you have Node.js and npm (or Yarn) installed on your computer. **Node.js 18 or higher is required.** If you are using an older Node version, you will need to provide a `fetch` polyfill. From your terminal, run:
 
 ```bash
 npm install itchio-downloader

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
     },
    "author": "Wal33D",
    "license": "ISC",
+   "engines": {
+      "node": ">=18"
+   },
    "dependencies": {
       "puppeteer": "^24.11.2",
       "yargs": "^18.0.0"


### PR DESCRIPTION
## Summary
- document Node.js 18+ requirement and polyfill note
- enforce Node.js >=18 via `engines` in package.json

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68662fa9f1d08324807fad1f2a0797a5