### PR TITLE
Add typed CLI arguments

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import yargs from 'yargs';
+import yargs, { Argv, ArgumentsCamelCase } from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { downloadGame } from './itchDownloader/downloadGame';
 import { DownloadGameParams } from './itchDownloader/types';
-
-const argv: any = yargs(hideBin(process.argv))
+import { CLIArgs } from './types/cli';
+const argv: ArgumentsCamelCase<CLIArgs> = (yargs(hideBin(process.argv)) as Argv<CLIArgs>)
    .option('url', {
       describe: 'The full URL to the game on itch.io',
       type: 'string'
@@ -35,7 +35,7 @@ const argv: any = yargs(hideBin(process.argv))
    })
    .help()
    .alias('help', 'h')
-   .parse();
+   .parseSync();
 
 const params: DownloadGameParams = {
    itchGameUrl: argv.url,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { DownloadGameParams, DownloadGameResponse, IItchRecord } from './itchDownloader/types';
 
 import { downloadGame } from './itchDownloader/downloadGame';
+import { CLIArgs } from './types/cli';
 
 // Export the functions from this index file, making them accessible to users of your package
-export { downloadGame, DownloadGameParams, DownloadGameResponse, IItchRecord };
+export { downloadGame, DownloadGameParams, DownloadGameResponse, IItchRecord, CLIArgs };

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -1,0 +1,6 @@
+export interface CLIArgs {
+   url?: string;
+   name?: string;
+   author?: string;
+   downloadDir?: string;
+}


### PR DESCRIPTION
## Summary
- add a `CLIArgs` interface
- use `CLIArgs` with `yargs` and `parseSync`
- re-export `CLIArgs` from the library

## Testing
- `npx tsc --noEmit`
- `npm run test:downloadSingle` *(fails: net::ERR_CERT_AUTHORITY_INVALID)*
- `npm run test:downloadMultiple` *(fails: net::ERR_CERT_AUTHORITY_INVALID)*

------
https://chatgpt.com/codex/tasks/task_b_68662f5e8dcc8324b734a090d9e6832a