### PR TITLE
Set up Jest examples and CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm test
+

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ export type DownloadGameResponse = {
 };
 ```
 
-## yarn test:downloadSingle --> example response
+## yarn example:downloadSingle --> example response
 
 Single Game Download Result
 

--- a/examples/downloadMultiple.ts
+++ b/examples/downloadMultiple.ts
@@ -1,5 +1,5 @@
-import { downloadGame } from '../itchDownloader/downloadGame';
-import { DownloadGameParams } from '../itchDownloader/types';
+import { downloadGame } from '../src/itchDownloader/downloadGame';
+import { DownloadGameParams } from '../src/itchDownloader/types';
 
 async function downloadMultipleGamesExample() {
    const gameParams: DownloadGameParams[] = [

--- a/examples/downloadSingle.ts
+++ b/examples/downloadSingle.ts
@@ -1,5 +1,5 @@
-import { downloadGame } from '../itchDownloader/downloadGame';
-import { DownloadGameParams } from '../itchDownloader/types';
+import { downloadGame } from '../src/itchDownloader/downloadGame';
+import { DownloadGameParams } from '../src/itchDownloader/types';
 
 async function downloadSingleGameExample() {
    const params: DownloadGameParams = {

--- a/examples/readme.md
+++ b/examples/readme.md
@@ -1,0 +1,3 @@
+// These files demonstrate how to use the library. Run them from the command
+// line, for example:
+//   yarn example:downloadSingle

--- a/examples/waitForFile.ts
+++ b/examples/waitForFile.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import assert from 'assert';
-import { waitForFile } from '../fileUtils/waitForFile';
+import { waitForFile } from '../src/fileUtils/waitForFile';
 
 async function runTests() {
   // Success scenario

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
         "dev": "nodemon --watch src --ext ts --exec \"ts-node ./src/index.ts\"",
         "build-cli": "npm run clean && tsc && shx chmod +x ./dist/cli.js",
         "prepublishOnly": "npm run build-cli",
-        "test:downloadSingle": "npm run build && ts-node ./src/tests/downloadSingle.ts",
-        "test:downloadMultiple": "npm run build && ts-node ./src/tests/downloadMultiple.ts",
-        "test:waitForFile": "npm run build && ts-node ./src/tests/waitForFile.test.ts"
+        "test": "jest",
+        "example:downloadSingle": "npm run build && ts-node ./examples/downloadSingle.ts",
+        "example:downloadMultiple": "npm run build && ts-node ./examples/downloadMultiple.ts",
+        "example:waitForFile": "npm run build && ts-node ./examples/waitForFile.ts"
     },
    "author": "Wal33D",
    "license": "ISC",

--- a/src/fileUtils/__tests__/readFile.test.ts
+++ b/src/fileUtils/__tests__/readFile.test.ts
@@ -1,0 +1,15 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { readFile } from '../readFile';
+
+describe('readFile', () => {
+  it('reads a single file', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'read-file-'));
+    const filePath = path.join(tempDir, 'file.txt');
+    fs.writeFileSync(filePath, 'hello');
+    const result = await readFile({ filePaths: filePath }) as any;
+    expect(result.read).toBe(true);
+    expect(result.content).toBe('hello');
+  });
+});

--- a/src/fileUtils/__tests__/renameFile.test.ts
+++ b/src/fileUtils/__tests__/renameFile.test.ts
@@ -1,0 +1,17 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { renameFile } from '../renameFile';
+
+describe('renameFile', () => {
+  it('renames a file and keeps extension when none provided', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rename-file-'));
+    const originalPath = path.join(tempDir, 'test.txt');
+    fs.writeFileSync(originalPath, 'content');
+
+    const result = await renameFile({ filePath: originalPath, desiredFileName: 'renamed' });
+    expect(result.status).toBe(true);
+    expect(result.newFilePath).toBe(path.join(tempDir, 'renamed.txt'));
+    expect(fs.existsSync(result.newFilePath!)).toBe(true);
+  });
+});

--- a/src/fileUtils/__tests__/waitForFile.test.ts
+++ b/src/fileUtils/__tests__/waitForFile.test.ts
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { waitForFile } from '../waitForFile';
+
+describe('waitForFile', () => {
+  it('resolves when .crdownload is renamed', async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wait-file-'));
+    const download = path.join(tempDir, 'file.crdownload');
+    fs.writeFileSync(download, '');
+
+    setTimeout(() => {
+      fs.renameSync(download, path.join(tempDir, 'file.txt'));
+    }, 300);
+
+    const result = await waitForFile({ downloadDirectory: tempDir, timeoutMs: 2000 });
+    expect(result.status).toBe(true);
+    expect(result.filePath?.endsWith('file.txt')).toBe(true);
+  });
+});

--- a/src/tests/readme.md
+++ b/src/tests/readme.md
@@ -1,1 +1,0 @@
-//Not Really tests, more like examples but you can run them from the command line for example yarn test:singleDownload


### PR DESCRIPTION
## Summary
- move example scripts to `examples/`
- update docs to use the new example path and scripts
- add Jest unit tests for file utilities
- enable `npm test` script
- run tests with GitHub Actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686630f851f483248af524077cf589df