### PR TITLE
Add parallel download option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,17 +55,17 @@ await downloadGame({
 
 ### Downloading Multiple Games
 
-To download multiple games, provide an array of parameters for each game. You can mix URL and name/author specifications within the same operation. An optional `concurrency` argument controls how many downloads run at the same time:
+To download multiple games, provide an array of parameters for each game. You can mix URL and name/author specifications within the same operation. An optional `concurrency` argument controls how many downloads run at the same time. Alternatively, set `parallel: true` on any item to run all downloads concurrently using `Promise.all`:
 
 ```javascript
 async function downloadMultipleGames() {
    const gameParams = [
       { name: 'manic-miners', author: 'baraklava' },
       { itchGameUrl: 'https://anotherdev.itch.io/another-game' },
-      { itchGameUrl: 'https://moregames.itch.io/better-game' }
+      { itchGameUrl: 'https://moregames.itch.io/better-game', parallel: true }
    ];
 
-   await downloadGame(gameParams, 2); // up to 2 downloads simultaneously
+   await downloadGame(gameParams, 2); // up to 2 downloads or set parallel to run all at once
 }
 downloadMultipleGames();
 ```
@@ -116,6 +116,8 @@ The `downloadGame` function accepts the following parameters within `DownloadGam
 -  `cleanDirectory`: (Optional) Whether to clean the directory before downloading the files.
 -  `concurrency`: (Optional) When providing an array of games, this sets how many downloads occur at once.
 
+  `parallel`: (Optional) If `true` when using an array of games, all downloads run concurrently using `Promise.all`.
+
 ## Types
 
 ```javascript
@@ -125,7 +127,8 @@ export type DownloadGameParams = {
    cleanDirectory?: boolean,
    desiredFileName?: string,
    desiredFileDirectory?: string,
-   itchGameUrl?: string
+   itchGameUrl?: string,
+   parallel?: boolean
 };
 
 export type DownloadGameResponse = {

--- a/src/itchDownloader/downloadGame.ts
+++ b/src/itchDownloader/downloadGame.ts
@@ -16,6 +16,11 @@ export async function downloadGame(
 ): Promise<DownloadGameResponse | DownloadGameResponse[]> {
    if (Array.isArray(params)) {
       const list = params as DownloadGameParams[];
+      const runParallel = list.some((p) => p.parallel);
+      if (runParallel) {
+         return Promise.all(list.map((p) => downloadGameSingle(p)));
+      }
+
       const limit = Math.max(concurrency, 1);
       const results: DownloadGameResponse[] = new Array(list.length);
       let index = 0;

--- a/src/itchDownloader/types.ts
+++ b/src/itchDownloader/types.ts
@@ -96,6 +96,8 @@ export type DownloadGameParams = {
    downloadDirectory?: string;
    itchGameUrl?: string;
    writeMetaData?: boolean;
+   /** When part of an array, set to true to run downloads concurrently */
+   parallel?: boolean;
 };
 
 export type DownloadGameResponse = {

--- a/src/tests/downloadMultiple.ts
+++ b/src/tests/downloadMultiple.ts
@@ -4,7 +4,7 @@ import { DownloadGameParams } from '../itchDownloader/types';
 async function downloadMultipleGamesExample() {
    const gameParams: DownloadGameParams[] = [
       { name: 'eyeless-jack', author: 'tayoodev' },
-      { name: 'manic-miners', author: 'baraklava' }
+      { name: 'manic-miners', author: 'baraklava', parallel: true }
    ];
 
    try {


### PR DESCRIPTION
## Summary
- add optional `parallel` property to `DownloadGameParams`
- run `downloadGame` calls in parallel when flag is set
- document the new option and update example
- show `parallel` usage in sample script

## Testing
- `npm run test:waitForFile`
- `npm run test:downloadSingle` *(fails: ERR_CERT_AUTHORITY_INVALID)*
- `npm run test:downloadMultiple` *(fails: ERR_CERT_AUTHORITY_INVALID)*

------
https://chatgpt.com/codex/tasks/task_b_686631307a8883249569098614d26043