### PR TITLE
Add example folder and CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ export type DownloadGameResponse = {
 };
 ```
 
-## yarn test:downloadSingle --> example response
+## npm run test:downloadSingle --> example response
 
 Single Game Download Result
 
@@ -167,6 +167,8 @@ const response = {
 };
 
 ```
+
+Example scripts used to produce this output are available in the `examples/` directory.
 
 ## Contributing
 

--- a/examples/downloadMultiple.ts
+++ b/examples/downloadMultiple.ts
@@ -1,5 +1,5 @@
-import { downloadGame } from '../itchDownloader/downloadGame';
-import { DownloadGameParams } from '../itchDownloader/types';
+import { downloadGame } from '../src/itchDownloader/downloadGame';
+import { DownloadGameParams } from '../src/itchDownloader/types';
 
 async function downloadMultipleGamesExample() {
    const gameParams: DownloadGameParams[] = [

--- a/examples/downloadSingle.ts
+++ b/examples/downloadSingle.ts
@@ -1,5 +1,5 @@
-import { downloadGame } from '../itchDownloader/downloadGame';
-import { DownloadGameParams } from '../itchDownloader/types';
+import { downloadGame } from '../src/itchDownloader/downloadGame';
+import { DownloadGameParams } from '../src/itchDownloader/types';
 
 async function downloadSingleGameExample() {
    const params: DownloadGameParams = {

--- a/examples/readme.md
+++ b/examples/readme.md
@@ -1,0 +1,2 @@
+// These files are example scripts demonstrating the downloader.
+// Run them with the npm scripts such as `npm run test:downloadSingle`.

--- a/examples/waitForFile.example.ts
+++ b/examples/waitForFile.example.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import assert from 'assert';
-import { waitForFile } from '../fileUtils/waitForFile';
+import { waitForFile } from '../src/fileUtils/waitForFile';
 
 async function runTests() {
   // Success scenario

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
         "dev": "nodemon --watch src --ext ts --exec \"ts-node ./src/index.ts\"",
         "build-cli": "npm run clean && tsc && shx chmod +x ./dist/cli.js",
         "prepublishOnly": "npm run build-cli",
-        "test:downloadSingle": "npm run build && ts-node ./src/tests/downloadSingle.ts",
-        "test:downloadMultiple": "npm run build && ts-node ./src/tests/downloadMultiple.ts",
-        "test:waitForFile": "npm run build && ts-node ./src/tests/waitForFile.test.ts"
+        "test": "jest",
+        "test:downloadSingle": "npm run build && ts-node ./examples/downloadSingle.ts",
+        "test:downloadMultiple": "npm run build && ts-node ./examples/downloadMultiple.ts",
+        "test:waitForFile": "npm run build && ts-node ./examples/waitForFile.example.ts"
     },
    "author": "Wal33D",
    "license": "ISC",

--- a/src/fileUtils/__tests__/waitForFile.test.ts
+++ b/src/fileUtils/__tests__/waitForFile.test.ts
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { waitForFile } from '../waitForFile';
+
+describe('waitForFile', () => {
+  it('resolves when a .crdownload file finishes', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wait-file-success-'));
+    const crdownload = path.join(tmpDir, 'testfile.crdownload');
+    fs.writeFileSync(crdownload, '');
+
+    setTimeout(() => {
+      fs.renameSync(crdownload, path.join(tmpDir, 'testfile.txt'));
+    }, 300);
+
+    const result = await waitForFile({ downloadDirectory: tmpDir, timeoutMs: 2000 });
+    expect(result.status).toBe(true);
+    expect(result.filePath).toBe(path.join(tmpDir, 'testfile.txt'));
+  });
+
+  it('times out if file never completes', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wait-file-timeout-'));
+    const crdownload = path.join(tmpDir, 'fail.crdownload');
+    fs.writeFileSync(crdownload, '');
+
+    const start = Date.now();
+    const result = await waitForFile({ downloadDirectory: tmpDir, timeoutMs: 500 });
+    const duration = Date.now() - start;
+    expect(result.status).toBe(false);
+    expect(duration).toBeGreaterThanOrEqual(500);
+  });
+});

--- a/src/tests/readme.md
+++ b/src/tests/readme.md
@@ -1,1 +1,0 @@
-//Not Really tests, more like examples but you can run them from the command line for example yarn test:singleDownload


### PR DESCRIPTION
## Summary
- move test scripts to `examples/`
- adjust npm scripts for examples
- update README to reference examples
- add Jest unit test for `waitForFile`
- create GitHub Actions workflow to run tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6866328aa51c832492b698eb2cdaab50