### PR TITLE
Add URL to parse result

### DIFF
--- a/src/itchDownloader/__tests__/parseItchGameUrl.test.ts
+++ b/src/itchDownloader/__tests__/parseItchGameUrl.test.ts
@@ -2,16 +2,20 @@ import { parseItchGameUrl } from '../parseItchGameUrl';
 
 describe('parseItchGameUrl', () => {
   it('parses a valid Itch.io url', () => {
-    const result = parseItchGameUrl({ itchGameUrl: 'https://author.itch.io/game' });
+    const url = 'https://author.itch.io/game';
+    const result = parseItchGameUrl({ itchGameUrl: url });
     expect(result.parsed).toBe(true);
     expect(result.author).toBe('author');
     expect(result.name).toBe('game');
+    expect(result.itchGameUrl).toBe(url);
   });
 
   it('returns parsed false for invalid url', () => {
-    const result = parseItchGameUrl({ itchGameUrl: 'https://example.com/game' });
+    const url = 'https://example.com/game';
+    const result = parseItchGameUrl({ itchGameUrl: url });
     expect(result.parsed).toBe(false);
     expect(result.author).toBeUndefined();
     expect(result.name).toBeUndefined();
+    expect(result.itchGameUrl).toBe(url);
   });
 });

--- a/src/itchDownloader/parseItchGameUrl.ts
+++ b/src/itchDownloader/parseItchGameUrl.ts
@@ -32,5 +32,5 @@ export const parseItchGameUrl = ({ itchGameUrl }: { itchGameUrl: string }): IPar
       message = error.message;
    }
 
-   return { parsed, author, name, domain, message } as IParsedItchGameUrl;
+   return { parsed, author, name, domain, message, itchGameUrl } as IParsedItchGameUrl;
 };


### PR DESCRIPTION
## Summary
- return the original URL from `parseItchGameUrl`
- assert returned URL in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686635116c048324be8c46369db72bfa