### PR TITLE
Align download directory parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ await downloadGame({ itchGameUrl: 'https://baraklava.itch.io/manic-miners' });
 await downloadGame({
    name: 'manic-miners',
    author: 'baraklava',
-   desiredFileDirectory: 'full file path', // Optional
+   downloadDirectory: 'full file path', // Optional
    cleanDirectory: true // Optional
 });
 ```
@@ -112,7 +112,7 @@ The `downloadGame` function accepts the following parameters within `DownloadGam
 
 -  `itchGameUrl`: (Optional) Direct URL to the game's itch.io page.
 -  `desiredFileName`: (Optional) Specify a custom filename for the downloaded file.
--  `desiredFileDirectory`: (Optional) Directory where the downloaded files should be saved.
+-  `downloadDirectory`: (Optional) Directory where the downloaded files should be saved.
 -  `cleanDirectory`: (Optional) Whether to clean the directory before downloading the files.
 -  `concurrency`: (Optional) When providing an array of games, this sets how many downloads occur at once.
 
@@ -126,7 +126,7 @@ export type DownloadGameParams = {
    author?: string,
    cleanDirectory?: boolean,
    desiredFileName?: string,
-   desiredFileDirectory?: string,
+   downloadDirectory?: string,
    itchGameUrl?: string,
    parallel?: boolean
 };

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -29,10 +29,10 @@ const argv = (0, yargs_1.default)((0, helpers_1.hideBin)(process.argv))
     describe: 'The author of the game',
     type: 'string'
 })
-    .option('downloadDir', {
-    describe: 'The filepath where the game will be downloaded',
-    type: 'string'
-})
+    .option('downloadDirectory', {
+        describe: 'The filepath where the game will be downloaded',
+        type: 'string'
+    })
     .check((argv) => {
     // Ensure either URL is provided or both name and author are provided
     if (argv.url) {
@@ -52,7 +52,7 @@ const params = {
     itchGameUrl: argv.url,
     name: argv.name,
     author: argv.author,
-    downloadDirectory: argv.downloadDir
+    downloadDirectory: argv.downloadDirectory
 };
 function run() {
     return __awaiter(this, void 0, void 0, function* () {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,7 +18,7 @@ const argv: ArgumentsCamelCase<CLIArgs> = (yargs(hideBin(process.argv)) as Argv<
       describe: 'The author of the game',
       type: 'string'
    })
-   .option('downloadDir', {
+   .option('downloadDirectory', {
       describe: 'The filepath where the game will be downloaded',
       type: 'string'
    })
@@ -41,7 +41,7 @@ const params: DownloadGameParams = {
    itchGameUrl: argv.url,
    name: argv.name,
    author: argv.author,
-   downloadDirectory: argv.downloadDir
+   downloadDirectory: argv.downloadDirectory
 };
 
 async function run() {

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -2,5 +2,5 @@ export interface CLIArgs {
    url?: string;
    name?: string;
    author?: string;
-   downloadDir?: string;
+   downloadDirectory?: string;
 }


### PR DESCRIPTION
## Summary
- unify config name as `downloadDirectory`
- update CLI arg type and option
- rebuild compiled CLI script
- document `downloadDirectory` in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6866351a4b28832482c0ca84e9a23e9c