### PR TITLE
Add comprehensive Jest tests

### DIFF
--- a/src/fileUtils/__tests__/createFile.test.ts
+++ b/src/fileUtils/__tests__/createFile.test.ts
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { createFile } from '../createFile';
+
+describe('createFile', () => {
+  it('creates a single file', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'create-file-'));
+    const filePath = path.join(tmpDir, 'single.txt');
+
+    const result = await createFile({ filePath, content: 'hello' }) as any;
+    expect(result.created).toBe(true);
+    expect(result.exists).toBe(true);
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(result.overwritten).toBe(false);
+    expect(result.hasParentDirectory).toBe(true);
+  });
+
+  it('creates multiple files', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'create-files-'));
+    const files = [
+      { filePath: path.join(tmpDir, 'a.txt'), content: 'a' },
+      { filePath: path.join(tmpDir, 'b.txt'), content: 'b' }
+    ];
+
+    const results = await createFile(files) as any[];
+    expect(results).toHaveLength(2);
+    results.forEach((r) => expect(r.created).toBe(true));
+    expect(fs.existsSync(files[0].filePath)).toBe(true);
+    expect(fs.existsSync(files[1].filePath)).toBe(true);
+  });
+});

--- a/src/fileUtils/__tests__/renameFile.test.ts
+++ b/src/fileUtils/__tests__/renameFile.test.ts
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { renameFile } from '../renameFile';
+
+describe('renameFile', () => {
+  it('renames a file keeping extension', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rename-file-'));
+    const original = path.join(tmpDir, 'old.txt');
+    fs.writeFileSync(original, 'data');
+
+    const result = await renameFile({ filePath: original, desiredFileName: 'new' });
+    expect(result.status).toBe(true);
+    const newPath = path.join(tmpDir, 'new.txt');
+    expect(result.newFilePath).toBe(newPath);
+    expect(fs.existsSync(newPath)).toBe(true);
+    expect(fs.existsSync(original)).toBe(false);
+  });
+
+  it('renames a file with new extension', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rename-file-'));
+    const original = path.join(tmpDir, 'old.txt');
+    fs.writeFileSync(original, 'data');
+
+    const result = await renameFile({ filePath: original, desiredFileExt: 'md' });
+    expect(result.status).toBe(true);
+    const newPath = path.join(tmpDir, 'old.md');
+    expect(result.newFilePath).toBe(newPath);
+    expect(fs.existsSync(newPath)).toBe(true);
+    expect(fs.existsSync(original)).toBe(false);
+  });
+});

--- a/src/fileUtils/__tests__/verifyFile.test.ts
+++ b/src/fileUtils/__tests__/verifyFile.test.ts
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { verifyFile } from '../verifyFile';
+
+describe('verifyFile', () => {
+  it('returns info for existing file', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'verify-file-'));
+    const filePath = path.join(tmpDir, 'test.txt');
+    fs.writeFileSync(filePath, 'hello');
+
+    const result = await verifyFile({ filePath });
+    expect(result.exists).toBe(true);
+    expect(result.isFile).toBe(true);
+    expect(result.size).toBe(Buffer.byteLength('hello'));
+  });
+
+  it('indicates missing file', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'verify-missing-'));
+    const filePath = path.join(tmpDir, 'missing.txt');
+
+    const result = await verifyFile({ filePath });
+    expect(result.exists).toBe(false);
+    expect(result.isFile).toBe(false);
+  });
+});

--- a/src/itchDownloader/__tests__/downloadGame.test.ts
+++ b/src/itchDownloader/__tests__/downloadGame.test.ts
@@ -1,0 +1,41 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { downloadGame } from '../downloadGame';
+import * as fetchProfile from '../fetchItchGameProfile';
+import * as initBrowser from '../initializeBrowser';
+import * as initiateDownload from '../initiateDownload';
+import * as waitFile from '../../fileUtils/waitForFile';
+import * as renameFileModule from '../../fileUtils/renameFile';
+import * as createFileModule from '../../fileUtils/createFile';
+
+describe('downloadGame', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('processes a download using mocks', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dg-test-'));
+    const itchRecord = { name: 'game', author: 'user', title: 'Game', itchMetaDataUrl: '', domain: 'itch.io' };
+
+    jest.spyOn(fetchProfile, 'fetchItchGameProfile').mockResolvedValue({ found: true, itchRecord, message: 'ok' });
+    const closeMock = jest.fn();
+    jest.spyOn(initBrowser, 'initializeBrowser').mockResolvedValue({ browser: { close: closeMock } as any, status: true, message: 'ok' });
+    jest.spyOn(initiateDownload, 'initiateDownload').mockResolvedValue({ status: true, message: 'ok' });
+    jest.spyOn(waitFile, 'waitForFile').mockResolvedValue({ status: true, message: 'done', filePath: path.join(tmpDir, 'game.zip') });
+    jest.spyOn(renameFileModule, 'renameFile').mockResolvedValue({ status: true, message: 'renamed', newFilePath: path.join(tmpDir, 'renamed.zip') });
+    const createSpy = jest.spyOn(createFileModule, 'createFile').mockResolvedValue({} as any);
+
+    const result = await downloadGame({ name: 'game', author: 'user', desiredFileName: 'renamed', downloadDirectory: tmpDir }) as any;
+
+    expect(result.status).toBe(true);
+    expect(result.filePath).toBe(path.join(tmpDir, 'renamed.zip'));
+    expect(result.metadataPath).toBe(path.join(tmpDir, 'game-metadata.json'));
+    expect(result.metaData).toEqual(itchRecord);
+    expect(createSpy).toHaveBeenCalledWith({
+      filePath: path.join(tmpDir, 'game-metadata.json'),
+      content: JSON.stringify(itchRecord, null, 2)
+    });
+    expect(closeMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- expand unit tests for file helpers: createFile, verifyFile, renameFile
- add mocked test for downloadGame to avoid network usage

## Testing
- `npm test -- --runInBand`

------
https://chatgpt.com/codex/tasks/task_b_6866352d21688324ab2066ac851a0f07