### PR TITLE
Fix packaging contents

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -25,4 +25,8 @@ yarn.lock
 /installations/
 /testOutput/*
 *.zip
+
+# Exclude examples and tests from the published package
+examples/
+src/**/__tests__/
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,9 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": [
+    "src/**/__tests__/**",
+    "src/**/*.test.ts"
+  ]
 }


### PR DESCRIPTION
## Summary
- prevent bundling examples and tests in npm package
- stop compiling test sources to `dist`

## Testing
- `npm test`
- `npm pack --dry-run`

------
https://chatgpt.com/codex/tasks/task_b_68663727a520832488d825016095f89b