### PR TITLE
Add unit tests for file utils and itch downloader

### DIFF
--- a/src/fileUtils/__tests__/createFile.test.ts
+++ b/src/fileUtils/__tests__/createFile.test.ts
@@ -29,4 +29,11 @@ describe('createFile', () => {
     expect(fs.existsSync(files[0].filePath)).toBe(true);
     expect(fs.existsSync(files[1].filePath)).toBe(true);
   });
+
+  it('throws when target path is a directory', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'create-file-dir-'));
+    await expect(
+      createFile({ filePath: dir, content: 'x' })
+    ).rejects.toThrow('Operation aborted');
+  });
 });

--- a/src/fileUtils/__tests__/deleteDirectoryOrFile.test.ts
+++ b/src/fileUtils/__tests__/deleteDirectoryOrFile.test.ts
@@ -1,0 +1,33 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { deleteDirectoryOrFile } from '../deleteDirectoryOrFile';
+
+describe('deleteDirectoryOrFile', () => {
+  it('removes a file', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'delete-file-'));
+    const file = path.join(tmpDir, 'test.txt');
+    fs.writeFileSync(file, 'content');
+
+    const result = await deleteDirectoryOrFile({ directoryPath: file });
+    expect(result.deleted).toBe(true);
+    expect(fs.existsSync(file)).toBe(false);
+  });
+
+  it('removes a directory recursively', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'delete-dir-'));
+    const sub = path.join(dir, 'sub');
+    fs.mkdirSync(sub);
+    fs.writeFileSync(path.join(sub, 'a.txt'), 'a');
+
+    const result = await deleteDirectoryOrFile({ directoryPath: dir });
+    expect(result.deleted).toBe(true);
+    expect(fs.existsSync(dir)).toBe(false);
+  });
+
+  it('returns false when path is missing', async () => {
+    const missing = path.join(os.tmpdir(), `missing-${Date.now()}`);
+    const result = await deleteDirectoryOrFile({ directoryPath: missing });
+    expect(result.deleted).toBe(false);
+  });
+});

--- a/src/itchDownloader/__tests__/downloadGame.test.ts
+++ b/src/itchDownloader/__tests__/downloadGame.test.ts
@@ -38,4 +38,13 @@ describe('downloadGame', () => {
     });
     expect(closeMock).toHaveBeenCalled();
   });
+
+  it('handles errors from fetchItchGameProfile', async () => {
+    jest.spyOn(fetchProfile, 'fetchItchGameProfile').mockRejectedValue(new Error('fail'));
+
+    const result = await downloadGame({ name: 'game', author: 'user' }) as any;
+
+    expect(result.status).toBe(false);
+    expect(result.message).toContain('fail');
+  });
 });

--- a/src/itchDownloader/__tests__/fetchItchGameProfile.test.ts
+++ b/src/itchDownloader/__tests__/fetchItchGameProfile.test.ts
@@ -1,0 +1,49 @@
+import { fetchItchGameProfile } from '../fetchItchGameProfile';
+import * as urlParser from '../parseItchGameUrl';
+import * as metadataParser from '../parseItchGameMetadata';
+
+describe('fetchItchGameProfile', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('combines url data and metadata', async () => {
+    jest.spyOn(urlParser, 'parseItchGameUrl').mockReturnValue({
+      parsed: true,
+      author: 'author',
+      name: 'game',
+      domain: 'itch.io',
+      itchGameUrl: 'https://author.itch.io/game',
+      message: 'ok'
+    } as any);
+
+    jest.spyOn(metadataParser, 'parseItchGameMetadata').mockResolvedValue({
+      jsonParsed: true,
+      message: 'ok',
+      title: 'Game',
+      coverImage: 'cover.jpg',
+      authors: [],
+      tags: [],
+      id: 1,
+      commentsLink: 'c',
+      selfLink: 's',
+      itchMetaDataUrl: 'https://author.itch.io/game/data.json'
+    } as any);
+
+    const result = await fetchItchGameProfile({ itchGameUrl: 'https://author.itch.io/game' });
+    expect(result.found).toBe(true);
+    expect(result.itchRecord?.author).toBe('author');
+    expect(result.itchRecord?.title).toBe('Game');
+  });
+
+  it('throws when both parsers fail', async () => {
+    jest.spyOn(urlParser, 'parseItchGameUrl').mockImplementation(() => {
+      throw new Error('bad url');
+    });
+    jest.spyOn(metadataParser, 'parseItchGameMetadata').mockRejectedValue(new Error('bad meta'));
+
+    await expect(
+      fetchItchGameProfile({ itchGameUrl: 'https://author.itch.io/game' })
+    ).rejects.toThrow('Both URL parsing and metadata fetching failed');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for deleteDirectoryOrFile
- add directory error case test for createFile
- add fetchItchGameProfile unit tests
- cover failure path in downloadGame

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6866372b46d8832481d44edd1d47c0c6