### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+

--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ When publishing to npm, the `prepublishOnly` script defined in `package.json` au
 3. Run `npm publish` (the `prepublishOnly` script builds the CLI).
 
 
+## Maintenance
+
+Dependabot automatically monitors dependencies and opens pull requests for updates.
+
 ## License
 
 Distributed under the ISC License.


### PR DESCRIPTION
## Summary
- add weekly Dependabot config for npm and GitHub Actions
- document Dependabot under Maintenance section in README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_686638980a3c8324b202658e1e49c6ef