### PR TITLE
Add basic wiki pages

### DIFF
--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -1,0 +1,51 @@
+# API Reference
+
+Itchio-Downloader exposes a single main function `downloadGame` along with related TypeScript types. Import it from the package root:
+
+```javascript
+const { downloadGame } = require('itchio-downloader');
+```
+
+## downloadGame(params, concurrency?)
+
+Downloads one or more games from itch.io. When an array of parameter objects is supplied, multiple games can be fetched sequentially or in parallel.
+
+### Parameters
+
+- `params` – Either a single `DownloadGameParams` object or an array of them. Each object accepts:
+  - `name` *(string, optional)* – Game name, used with `author`.
+  - `author` *(string, optional)* – Author's username on itch.io.
+  - `itchGameUrl` *(string, optional)* – Direct URL to the game's page.
+  - `desiredFileName` *(string, optional)* – Rename the downloaded file.
+  - `downloadDirectory` *(string, optional)* – Directory for the downloaded files.
+  - `cleanDirectory` *(boolean, optional)* – Remove existing files in the directory before downloading.
+  - `writeMetaData` *(boolean, optional)* – Write a metadata JSON file alongside the download.
+  - `parallel` *(boolean, optional)* – When used inside an array, run this download concurrently via `Promise.all`.
+- `concurrency` *(number, optional)* – When `params` is an array and `parallel` is not set, limits how many downloads happen at once. Defaults to `1`.
+
+### Returns
+
+A promise that resolves to `DownloadGameResponse` or an array of responses.
+
+```javascript
+type DownloadGameResponse = {
+  status: boolean;
+  message: string;
+  metaData?: IItchRecord;
+  metadataPath?: string;
+  filePath?: string;
+};
+```
+
+The `metaData` object mirrors the information fetched from the game's `data.json` file.
+
+## Example
+
+```javascript
+await downloadGame({
+  itchGameUrl: 'https://baraklava.itch.io/manic-miners',
+  desiredFileName: 'manic-miners-latest'
+});
+```
+
+See the [Examples](Examples.md) page for more sample scripts.

--- a/wiki/CLI.md
+++ b/wiki/CLI.md
@@ -1,0 +1,21 @@
+# Command Line Reference
+
+Build the CLI with `npm run build-cli` and run it using `itchio-downloader [options]`.
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `--url` | Full URL to the game on itch.io |
+| `--name` | Name of the game to download (used with `--author`) |
+| `--author` | Username of the game's author |
+| `--downloadDirectory` | Directory where the file should be saved |
+| `-h, --help` | Display usage information |
+
+Provide either a URL or both a name and author.
+
+Example:
+
+```bash
+itchio-downloader --url "https://baraklava.itch.io/manic-miners"
+```

--- a/wiki/Examples.md
+++ b/wiki/Examples.md
@@ -1,0 +1,15 @@
+# Examples
+
+This repository includes small sample scripts under the `examples/` directory.
+
+- **downloadSingle.ts** – download one game using a URL or a name/author pair.
+- **downloadMultiple.ts** – queue several games for download.
+- **waitForFile.example.ts** – demonstrate the `waitForFile` utility.
+
+Run them with npm scripts:
+
+```bash
+npm run test:downloadSingle   # single download
+npm run test:downloadMultiple # multiple downloads
+npm run test:waitForFile      # waitForFile demo
+```

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,11 @@
+# Itchio-Downloader
+
+Itchio-Downloader is a Node.js library for downloading free games directly from [itch.io](https://itch.io). The package exposes an API for programmatic downloads and a small command line interface.
+
+## Links
+
+- [API Reference](API-Reference.md)
+- [CLI Usage](CLI.md)
+- [Examples](Examples.md)
+
+The project requires **Node.js 18 or later** because it relies on the built in `fetch` API. See the repository [README](../README.md) for a full quick start guide and additional documentation.


### PR DESCRIPTION
## Summary
- create initial wiki docs including Home, API Reference, CLI, and Examples pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68663e96b12c83248970fe3427e55652