### PR TITLE
Add debugging guide and references

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ yarn add itchio-downloader
 ```
 
 See [wiki/CLI.md](wiki/CLI.md) for a reference of available command line options.
+For debugging tips and verbose logging instructions, see [wiki/Debugging.md](wiki/Debugging.md).
 
 ## Usage
 

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -49,3 +49,4 @@ await downloadGame({
 ```
 
 See the [Examples](Examples.md) page for more sample scripts.
+For troubleshooting and debug logs, see the [Debugging](Debugging.md) guide.

--- a/wiki/Debugging.md
+++ b/wiki/Debugging.md
@@ -1,0 +1,23 @@
+# Debugging
+
+This page covers ways to diagnose issues when using **Itchio-Downloader**.
+
+## Enable verbose logs
+
+Set the environment variable `DEBUG_DOWNLOAD_GAME=true` before running your script or the CLI. When enabled, the library prints helpful messages about each step of the download process.
+
+Example:
+
+```bash
+DEBUG_DOWNLOAD_GAME=true node myScript.js
+# or
+DEBUG_DOWNLOAD_GAME=true itchio-downloader --url "https://example.itch.io/game"
+```
+
+## Troubleshooting tips
+
+- **Browser fails to launch** – Puppeteer requires a recent version of Chromium and certain system libraries. On Linux, install packages such as `libnss3`, `libatk-bridge2.0-0`, and `libxcb-dri3-0`. You can also try running with root privileges or passing additional flags if sandboxing issues occur.
+- **Downloads time out or hang** – The downloader waits up to 30 seconds for the file to appear. Slow connections may need more time. Ensure your internet connection is stable and that itch.io is reachable. Re-run with debug logging enabled to see where the process stops.
+- **Browser closes unexpectedly** – Make sure no other process is killing the spawned browser. On headless systems you can set `headless: false` in `initializeBrowser.ts` for interactive debugging.
+
+If problems persist, open an issue on GitHub with the debug logs attached.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -7,5 +7,6 @@ Itchio-Downloader is a Node.js library for downloading free games directly from 
 - [API Reference](API-Reference.md)
 - [CLI Usage](CLI.md)
 - [Examples](Examples.md)
+- [Debugging](Debugging.md)
 
 The project requires **Node.js 18 or later** because it relies on the built in `fetch` API. See the repository [README](../README.md) for a full quick start guide and additional documentation.


### PR DESCRIPTION
## Summary
- add `wiki/Debugging.md` with info on DEBUG_DOWNLOAD_GAME
- link the new page from `Home.md`
- mention debugging guide in `API-Reference.md`
- reference the wiki debugging page from the main README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_686642b327f483249ea080300f32ab7f