### PR TITLE
Centralize CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,42 +109,10 @@ downloadMultipleGames();
 
 ## Command Line Usage
 
-To use Itchio-Downloader from the command line:
-
-1. First, ensure the CLI is built:
-
-   ```bash
-   npm run build-cli
-   # or
-   yarn build-cli
-   ```
-
-2. Run the command with the required options. For example:
-
-   ```bash
-   itchio-downloader --name "manic miners" --author "baraklava"
-   ```
-
-   *Quick example:* download a game by URL:
-
-   ```bash
-   itchio-downloader --url "https://baraklava.itch.io/manic-miners"
-   ```
-
-   This command will start the download process and provide output similar to:
-
-   ```
-   Starting downloadGameSingle function...
-   Game profile fetched successfully: https://baraklava.itch.io/manic-miners
-   Download directory set C:\Users\Aquataze\AppData\Local\ItchDownloader\manic-miners
-   Downloading...
-   Download and file operations successful.
-   Game Download Result: {
-      status: true,
-      message: 'Download and file operations successful.',
-      filePath: 'C:\\Users\\Aquataze\\AppData\\Local\\ItchDownloader\\manic-miners\\ManicMinersV1.0.zip'
-   }
-   ```
+Build the CLI with `npm run build-cli` (or `yarn build-cli`) and then run
+`itchio-downloader` with the desired options. See
+[wiki/CLI.md](wiki/CLI.md) for complete usage instructions and all available
+flags.
 
 ## Configuration Options
 

--- a/wiki/CLI.md
+++ b/wiki/CLI.md
@@ -1,6 +1,16 @@
 # Command Line Reference
 
-The CLI allows you to download games directly from a terminal. Build the CLI with `npm run build-cli` before use.
+The CLI allows you to download games directly from a terminal.
+
+Build the executable before running:
+
+```bash
+npm run build-cli
+# or
+yarn build-cli
+```
+
+Then invoke the command:
 
 ```bash
 itchio-downloader [options]
@@ -18,8 +28,12 @@ itchio-downloader [options]
 
 You must provide either a URL or both a name and author.
 
-Example:
+### Examples
 
 ```bash
+# Using a URL
 itchio-downloader --url "https://baraklava.itch.io/manic-miners"
+
+# Using name and author
+itchio-downloader --name "manic miners" --author "baraklava"
 ```


### PR DESCRIPTION
## Summary
- reference CLI docs instead of detailed instructions in README
- expand `wiki/CLI.md` with build steps and examples

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686642b232a88324b141018940b5a017