### PR TITLE
Add advanced usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ await downloadGame({
 
 ### Downloading Multiple Games
 
-To download multiple games, provide an array of parameters for each game. You can mix URL and name/author specifications within the same operation. An optional `concurrency` argument controls how many downloads run at the same time. Alternatively, set `parallel: true` on any item to run all downloads concurrently using `Promise.all`:
+To download multiple games, provide an array of parameters for each game. You can mix URL and name/author specifications within the same operation. An optional `concurrency` argument controls how many downloads run at the same time. Alternatively, set `parallel: true` on any item to run all downloads concurrently using `Promise.all`. See the [Advanced Usage](wiki/Advanced-Usage.md) page for more concurrency examples and custom file paths:
 
 ```javascript
 async function downloadMultipleGames() {

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -49,3 +49,4 @@ await downloadGame({
 ```
 
 See the [Examples](Examples.md) page for more sample scripts.
+For concurrency and custom path examples, see the [Advanced Usage](Advanced-Usage.md) page.

--- a/wiki/Advanced-Usage.md
+++ b/wiki/Advanced-Usage.md
@@ -1,0 +1,42 @@
+# Advanced Usage
+
+This page contains additional examples for managing multiple downloads and customizing output paths.
+
+## Concurrent Downloads with `concurrency`
+
+Limit how many downloads run at once by passing a `concurrency` value when downloading an array of games:
+
+```javascript
+const games = [
+  { name: 'manic-miners', author: 'baraklava' },
+  { name: 'another-game', author: 'anotherdev' },
+  { name: 'better-game', author: 'moregames' }
+];
+
+await downloadGame(games, 2); // up to two downloads at the same time
+```
+
+## Running Downloads in Parallel
+
+Set `parallel: true` on each item to execute all downloads concurrently using `Promise.all`:
+
+```javascript
+const games = [
+  { itchGameUrl: 'https://dev1.itch.io/game-one', parallel: true },
+  { itchGameUrl: 'https://dev2.itch.io/game-two', parallel: true }
+];
+
+await downloadGame(games); // runs both downloads in parallel
+```
+
+## Custom File Paths
+
+You can control where files are saved and what they are named by using `downloadDirectory` and `desiredFileName`:
+
+```javascript
+await downloadGame({
+  itchGameUrl: 'https://baraklava.itch.io/manic-miners',
+  downloadDirectory: '/path/to/games',
+  desiredFileName: 'manic-miners-latest.zip'
+});
+```

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -7,5 +7,6 @@ Itchio-Downloader is a Node.js library for downloading free games directly from 
 - [API Reference](API-Reference.md)
 - [CLI Usage](CLI.md)
 - [Examples](Examples.md)
+- [Advanced Usage](Advanced-Usage.md)
 
 The project requires **Node.js 18 or later** because it relies on the built in `fetch` API. See the repository [README](../README.md) for a full quick start guide and additional documentation.


### PR DESCRIPTION
## Summary
- document concurrency, parallel downloads, and custom file paths in `wiki/Advanced-Usage.md`
- link `Advanced Usage` page from wiki home
- cross link from README and API reference

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_b_686642b0a88c832484fba20244c420ad