### PR TITLE
Remove cleanDirectory from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ await downloadGame({
    name: 'manic-miners',
    author: 'baraklava',
    downloadDirectory: 'full file path', // Optional
-   cleanDirectory: true // Optional
 });
 ```
 
@@ -158,7 +157,7 @@ The `downloadGame` function accepts the following parameters within `DownloadGam
 -  `itchGameUrl`: (Optional) Direct URL to the game's itch.io page.
 -  `desiredFileName`: (Optional) Specify a custom filename for the downloaded file.
 -  `downloadDirectory`: (Optional) Directory where the downloaded files should be saved.
--  `cleanDirectory`: (Optional) Whether to clean the directory before downloading the files.
+-  `writeMetaData`: (Optional) Save a metadata JSON file alongside the download. Default is `true`.
 -  `concurrency`: (Optional) When providing an array of games, this sets how many downloads occur at once.
 
   `parallel`: (Optional) If `true` when using an array of games, all downloads run concurrently using `Promise.all`.
@@ -169,10 +168,10 @@ The `downloadGame` function accepts the following parameters within `DownloadGam
 export type DownloadGameParams = {
    name?: string,
    author?: string,
-   cleanDirectory?: boolean,
    desiredFileName?: string,
    downloadDirectory?: string,
    itchGameUrl?: string,
+   writeMetaData?: boolean,
    parallel?: boolean
 };
 

--- a/wiki/API-Reference.md
+++ b/wiki/API-Reference.md
@@ -18,7 +18,6 @@ Downloads one or more games from itch.io. When an array of parameter objects is 
   - `itchGameUrl` *(string, optional)* – Direct URL to the game's page.
   - `desiredFileName` *(string, optional)* – Rename the downloaded file.
   - `downloadDirectory` *(string, optional)* – Directory for the downloaded files.
-  - `cleanDirectory` *(boolean, optional)* – Remove existing files in the directory before downloading.
   - `writeMetaData` *(boolean, optional)* – Write a metadata JSON file alongside the download.
   - `parallel` *(boolean, optional)* – When used inside an array, run this download concurrently via `Promise.all`.
 - `concurrency` *(number, optional)* – When `params` is an array and `parallel` is not set, limits how many downloads happen at once. Defaults to `1`.


### PR DESCRIPTION
## Summary
- remove `cleanDirectory` usage from README
- document `writeMetaData` parameter instead
- update API reference accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686642caa55c8324b1b1631700a164a8