### PR TITLE
Run tests, bump version, attempt publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "itchio-downloader",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "itchio-downloader",
-      "version": "0.7.7",
+      "version": "0.7.8",
       "license": "ISC",
       "dependencies": {
         "puppeteer": "^24.11.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itchio-downloader",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Programatically download games from itch.io using Node",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary
- run tests after installing dependencies
- bump version to 0.7.8 via `npm version patch`

## Testing
- `npm test`
- `npm publish` *(fails: need auth)*

------
https://chatgpt.com/codex/tasks/task_b_6866474853c08324a1311cb0c90846ec