### PR TITLE
Add roadmap docs for cookie reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ More documentation:
 - [docs/CLI.md](docs/CLI.md) – Command line usage
 - [docs/Advanced-Usage.md](docs/Advanced-Usage.md) – Concurrency and custom paths
 - [docs/Debugging.md](docs/Debugging.md) – Troubleshooting tips
+- [docs/Roadmap.md](docs/Roadmap.md) – Future development plans
 - [CONTRIBUTING.md](CONTRIBUTING.md) – Contribution guidelines
 - [CHANGELOG.md](CHANGELOG.md) – Release history
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -1,0 +1,15 @@
+# Roadmap
+
+This page tracks planned improvements for **Itchio-Downloader**. Items may change as the project evolves.
+
+## Reusable Cookies
+
+Switching to a reusable cookie will reduce the overhead of launching Puppeteer for every download. The basic idea is:
+
+1. **Capture cookies** from the first Puppeteer session using `page.cookies()` and write them to `cookies.json`.
+2. **Reuse cookies** by loading the file and sending them in a `cookie` header when downloading via `fetch`.
+3. **Refresh periodically**. If a download fails or the cookies are older than a set threshold, open Puppeteer again to generate a new `cookies.json`.
+4. Provide a small helper (CLI command or script) for manually updating the cookie file when needed.
+
+This approach allows most downloads to run without opening a headless browser while still remaining compatible with itch.io's authentication.
+


### PR DESCRIPTION
## Summary
- document planned use of reusable cookies for itch.io sessions
- link the new Roadmap doc from README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_686721e1b70c83249927d539c6c8d03a