### PR TITLE
Improve roadmap documentation

### DIFF
--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -13,3 +13,30 @@ Switching to a reusable cookie will reduce the overhead of launching Puppeteer f
 
 This approach allows most downloads to run without opening a headless browser while still remaining compatible with itch.io's authentication.
 
+
+## Configuration File Support
+
+Add the ability for the CLI to read a JSON or YAML file containing a list of games and default options. The steps involve:
+
+1. Implement a `--config` option that accepts the path to the file.
+2. Parse each entry and merge it with any CLI flags provided.
+3. Validate the structure of the file before initiating downloads.
+
+This feature will simplify batch operations and allow sharing predefined lists of games.
+
+## CLI Enhancements
+
+- Expose a `--concurrency` flag matching the library function.
+- Display basic progress output for each download.
+- Provide a `--update-cookies` command to regenerate the cookie file on demand.
+
+## Robust Error Handling
+
+- Retry failed downloads a few times with exponential backoff.
+- Detect existing files and automatically skip or rename them.
+- Include HTTP status codes and additional context in error messages.
+
+## Testing Improvements
+
+- Expand unit tests for the CLI and concurrency logic.
+- Add integration tests using a local server to simulate downloads.


### PR DESCRIPTION
## Summary
- flesh out the roadmap with configuration file support, CLI plans and more

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68674ae049d88324849ae5a7a559d8de