### PR TITLE
Fix invalid package.json trailing char

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,5 +49,6 @@
     "url": "https://github.com/Wal33D/itchio-downloader.git"
   },
   "homepage": "https://github.com/Wal33D/itchio-downloader",
-  "packageManager": "pnpm@9.15.4"=
+  "packageManager": "pnpm@9.15.4"
 }
+


### PR DESCRIPTION
## Summary
- fix a typo in `package.json` that caused `pnpm install` to fail

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_68675c4798e483249352022e3f26d270