### PR TITLE
Suppress console error in fetch profile test

### DIFF
--- a/src/itchDownloader/__tests__/fetchItchGameProfile.test.ts
+++ b/src/itchDownloader/__tests__/fetchItchGameProfile.test.ts
@@ -39,6 +39,8 @@ describe('fetchItchGameProfile', () => {
   });
 
   it('throws when both parsers fail', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
     jest.spyOn(urlParser, 'parseItchGameUrl').mockImplementation(() => {
       throw new Error('bad url');
     });
@@ -49,5 +51,6 @@ describe('fetchItchGameProfile', () => {
     await expect(
       fetchItchGameProfile({ itchGameUrl: 'https://author.itch.io/game' }),
     ).rejects.toThrow('Both URL parsing and metadata fetching failed');
+    expect(errorSpy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- silence the console error produced when testing error handling for `fetchItchGameProfile`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_68676b20e3048324856c29d7dc2b5a93