### PR TITLE
Fix CI by installing pnpm before Node setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: 'pnpm'
-      - run: corepack enable
       - run: pnpm install
       - run: pnpm run lint
       - run: pnpm run build
@@ -35,12 +37,14 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: '18'
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
-      - run: corepack enable
       - run: pnpm install
       - run: pnpm publish
         env:


### PR DESCRIPTION
## Summary
- install pnpm via `pnpm/action-setup` before running `actions/setup-node`
- remove unnecessary `corepack enable` calls

## Testing
- `pnpm install`
- `pnpm test`
- `pnpm run lint`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_b_686772a20f388324aba51328217f4de3