### PR TITLE
Add concurrency flag to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ If installed globally you can run the command directly:
 itchio-downloader --help
 ```
 
+Limit concurrent downloads when using an array of games:
+
+```bash
+itchio-downloader --concurrency 2 --url "https://baraklava.itch.io/manic-miners"
+```
+
 See [docs/CLI.md](docs/CLI.md) for CLI options and [docs/Debugging.md](docs/Debugging.md) for verbose logging.
 
 ## Usage

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -27,6 +27,7 @@ itchio-downloader [options]
 | `--name`              | Name of the game to download (used with `--author`) |
 | `--author`            | Username of the game's author                       |
 | `--downloadDirectory` | Directory where the file should be saved            |
+| `--concurrency`       | Max downloads at once when using an array           |
 | `-h, --help`          | Display usage information                           |
 
 You must provide either a URL or both a name and author.
@@ -39,6 +40,9 @@ itchio-downloader --url "https://baraklava.itch.io/manic-miners"
 
 # Using name and author
 itchio-downloader --name "manic miners" --author "baraklava"
+
+# Limiting concurrency
+itchio-downloader --url "https://baraklava.itch.io/manic-miners" --concurrency 2
 ```
 
 If you have the package installed locally without `-g`, run the examples with `npx itchio-downloader` or `pnpm dlx itchio-downloader`.

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -69,12 +69,15 @@ describe('cli', () => {
       '/tmp',
     ]);
 
-    expect(mock).toHaveBeenCalledWith({
-      itchGameUrl: 'https://author.itch.io/game',
-      name: undefined,
-      author: undefined,
-      downloadDirectory: '/tmp',
-    });
+    expect(mock).toHaveBeenCalledWith(
+      {
+        itchGameUrl: 'https://author.itch.io/game',
+        name: undefined,
+        author: undefined,
+        downloadDirectory: '/tmp',
+      },
+      1,
+    );
     expect(logSpy).toHaveBeenCalledWith('Game Download Result:', 'ok');
   });
 
@@ -86,12 +89,42 @@ describe('cli', () => {
 
     await run(['node', 'cli.ts', '--name', 'game', '--author', 'user']);
 
-    expect(mock).toHaveBeenCalledWith({
-      itchGameUrl: undefined,
-      name: 'game',
-      author: 'user',
-      downloadDirectory: undefined,
-    });
+    expect(mock).toHaveBeenCalledWith(
+      {
+        itchGameUrl: undefined,
+        name: 'game',
+        author: 'user',
+        downloadDirectory: undefined,
+      },
+      1,
+    );
+    expect(logSpy).toHaveBeenCalled();
+  });
+
+  it('passes a custom concurrency value', async () => {
+    const mock = jest
+      .spyOn(downloadGameModule, 'downloadGame')
+      .mockResolvedValue('c' as any);
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    await run([
+      'node',
+      'cli.ts',
+      '--url',
+      'https://author.itch.io/game',
+      '--concurrency',
+      '3',
+    ]);
+
+    expect(mock).toHaveBeenCalledWith(
+      {
+        itchGameUrl: 'https://author.itch.io/game',
+        name: undefined,
+        author: undefined,
+        downloadDirectory: undefined,
+      },
+      3,
+    );
     expect(logSpy).toHaveBeenCalled();
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,6 +28,12 @@ export async function run(argvInput: string[] = process.argv) {
       describe: 'The filepath where the game will be downloaded',
       type: 'string',
     })
+    .option('concurrency', {
+      describe:
+        'Maximum number of simultaneous downloads when passing an array of games',
+      type: 'number',
+      default: 1,
+    })
     .check((args) => {
       // Ensure either URL is provided or both name and author are provided
       if (args.url) {
@@ -49,8 +55,10 @@ export async function run(argvInput: string[] = process.argv) {
     downloadDirectory: argv.downloadDirectory,
   };
 
+  const concurrency = Number(argv.concurrency ?? 1);
+
   try {
-    const result = await downloadGame(params);
+    const result = await downloadGame(params, concurrency);
     console.log('Game Download Result:', result);
   } catch (error) {
     console.error('Error downloading game:', error);

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -3,4 +3,5 @@ export interface CLIArgs {
   name?: string;
   author?: string;
   downloadDirectory?: string;
+  concurrency?: number;
 }


### PR DESCRIPTION
## Summary
- support `--concurrency` option in the CLI
- pass the concurrency value to `downloadGame`
- update tests for new argument
- document new flag in docs
- show concurrency usage in README

## Testing
- `pnpm test --silent`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_b_6867776da4a88324995b221bc5ebe566