### PR TITLE
Add concurrency flag to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,12 @@ See [docs/Advanced-Usage.md](docs/Advanced-Usage.md) for more concurrency and cu
 
 ## Command Line Usage
 
-Build the CLI with `pnpm run build-cli`, then run `itchio-downloader` with your options. Full details are in [docs/CLI.md](docs/CLI.md).
+Build the CLI with `pnpm run build-cli`, then run `itchio-downloader` with your options. The `--concurrency` flag limits how many downloads run at once when supplying a list of games. Full details are in [docs/CLI.md](docs/CLI.md).
+
+```bash
+# Example limiting concurrency
+itchio-downloader --url "https://baraklava.itch.io/manic-miners" --concurrency 2
+```
 
 ## Configuration Options
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -27,6 +27,7 @@ itchio-downloader [options]
 | `--name`              | Name of the game to download (used with `--author`) |
 | `--author`            | Username of the game's author                       |
 | `--downloadDirectory` | Directory where the file should be saved            |
+| `--concurrency`       | Max simultaneous downloads when using a list        |
 | `-h, --help`          | Display usage information                           |
 
 You must provide either a URL or both a name and author.
@@ -39,6 +40,9 @@ itchio-downloader --url "https://baraklava.itch.io/manic-miners"
 
 # Using name and author
 itchio-downloader --name "manic miners" --author "baraklava"
+
+# Limiting concurrent downloads when using a list
+itchio-downloader --url "https://baraklava.itch.io/manic-miners" --concurrency 2
 ```
 
 If you have the package installed locally without `-g`, run the examples with `npx itchio-downloader` or `pnpm dlx itchio-downloader`.

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -69,12 +69,15 @@ describe('cli', () => {
       '/tmp',
     ]);
 
-    expect(mock).toHaveBeenCalledWith({
-      itchGameUrl: 'https://author.itch.io/game',
-      name: undefined,
-      author: undefined,
-      downloadDirectory: '/tmp',
-    });
+    expect(mock).toHaveBeenCalledWith(
+      {
+        itchGameUrl: 'https://author.itch.io/game',
+        name: undefined,
+        author: undefined,
+        downloadDirectory: '/tmp',
+      },
+      1,
+    );
     expect(logSpy).toHaveBeenCalledWith('Game Download Result:', 'ok');
   });
 
@@ -86,12 +89,15 @@ describe('cli', () => {
 
     await run(['node', 'cli.ts', '--name', 'game', '--author', 'user']);
 
-    expect(mock).toHaveBeenCalledWith({
-      itchGameUrl: undefined,
-      name: 'game',
-      author: 'user',
-      downloadDirectory: undefined,
-    });
+    expect(mock).toHaveBeenCalledWith(
+      {
+        itchGameUrl: undefined,
+        name: 'game',
+        author: 'user',
+        downloadDirectory: undefined,
+      },
+      1,
+    );
     expect(logSpy).toHaveBeenCalled();
   });
 
@@ -112,14 +118,44 @@ describe('cli', () => {
       '100',
     ]);
 
-    expect(mock).toHaveBeenCalledWith({
-      itchGameUrl: 'https://author.itch.io/game',
-      name: undefined,
-      author: undefined,
-      downloadDirectory: undefined,
-      retries: 2,
-      retryDelayMs: 100,
-    });
+    expect(mock).toHaveBeenCalledWith(
+      {
+        itchGameUrl: 'https://author.itch.io/game',
+        name: undefined,
+        author: undefined,
+        downloadDirectory: undefined,
+        retries: 2,
+        retryDelayMs: 100,
+      },
+      1,
+    );
+    expect(logSpy).toHaveBeenCalled();
+  });
+
+  it('forwards concurrency option', async () => {
+    const mock = jest
+      .spyOn(downloadGameModule, 'downloadGame')
+      .mockResolvedValue('ok' as any);
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    await run([
+      'node',
+      'cli.ts',
+      '--url',
+      'https://author.itch.io/game',
+      '--concurrency',
+      '3',
+    ]);
+
+    expect(mock).toHaveBeenCalledWith(
+      {
+        itchGameUrl: 'https://author.itch.io/game',
+        name: undefined,
+        author: undefined,
+        downloadDirectory: undefined,
+      },
+      3,
+    );
     expect(logSpy).toHaveBeenCalled();
   });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,6 +38,12 @@ export async function run(argvInput: string[] = process.argv) {
       type: 'number',
       default: 500,
     })
+    .option('concurrency', {
+      describe:
+        'Maximum number of simultaneous downloads when providing a list of games',
+      type: 'number',
+      default: 1,
+    })
     .check((args) => {
       // Ensure either URL is provided or both name and author are provided
       if (args.url) {
@@ -62,8 +68,11 @@ export async function run(argvInput: string[] = process.argv) {
       argv.retryDelay !== undefined ? Number(argv.retryDelay) : undefined,
   };
 
+  const concurrency =
+    argv.concurrency !== undefined ? Number(argv.concurrency) : 1;
+
   try {
-    const result = await downloadGame(params);
+    const result = await downloadGame(params, concurrency);
     console.log('Game Download Result:', result);
   } catch (error) {
     console.error('Error downloading game:', error);

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -5,4 +5,5 @@ export interface CLIArgs {
   downloadDirectory?: string;
   retries?: number;
   retryDelay?: number;
+  concurrency?: number;
 }


### PR DESCRIPTION
## Summary
- extend CLIArgs to include `concurrency`
- expose `--concurrency` option in CLI with yargs
- forward concurrency value to `downloadGame`
- update tests for new argument
- document the flag in CLI docs and README

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_68677b27621083248f49c67ee537ee72