### PR TITLE
Fix CI by removing explicit pnpm version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: '18'
@@ -38,8 +36,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: '18'


### PR DESCRIPTION
## Summary
- fix GitHub Actions workflow by removing redundant `version` setting from `pnpm/action-setup`

## Testing
- `pnpm run lint`
- `pnpm run build`
- `pnpm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_b_686f4da953408324b70fe34c22ac7c5a