### PR TITLE
Add collection download support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ I built this tool to create a launcher for free games and released it so others 
 
 - **Direct Downloads**: Get games by URL or by name and author—no desktop GUI or Butler.
 - **Batch Operations**: Download multiple games in one run.
+- **Collection Downloads**: Fetch every game from a collection URL.
 - **Customization**: Rename files and choose download directories.
 - **Simplicity**: Only a URL or author and title is required.
 - **API Key Optional**: Use an itch.io API key for authenticated downloads.
@@ -130,6 +131,9 @@ Build the CLI with `pnpm run build-cli`, then run `itchio-downloader` with your 
 ```bash
 # Example limiting concurrency
 itchio-downloader --url "https://baraklava.itch.io/manic-miners" --concurrency 2
+
+# Download an entire collection
+itchio-downloader --collection "https://itch.io/c/123/example"
 ```
 
 ## Configuration Options

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -21,18 +21,19 @@ itchio-downloader [options]
 
 ## Options
 
-| Flag                  | Description                                         |
-| --------------------- | --------------------------------------------------- |
-| `--url`               | Full URL to the game on itch.io                     |
-| `--name`              | Name of the game to download (used with `--author`) |
-| `--author`            | Username of the game's author                       |
+| Flag                  | Description                                                              |
+| --------------------- | ------------------------------------------------------------------------ |
+| `--url`               | Full URL to the game on itch.io                                          |
+| `--collection`        | URL to a collection on itch.io                                           |
+| `--name`              | Name of the game to download (used with `--author`)                      |
+| `--author`            | Username of the game's author                                            |
 | `--apiKey`            | itch.io API key for authenticated downloads (defaults to `ITCH_API_KEY`) |
-| `--downloadDirectory` | Directory where the file should be saved            |
-| `--memory`            | Store the downloaded file in memory                 |
-| `--concurrency`       | Max simultaneous downloads when using a list        |
-| `-h, --help`          | Display usage information                           |
+| `--downloadDirectory` | Directory where the file should be saved                                 |
+| `--memory`            | Store the downloaded file in memory                                      |
+| `--concurrency`       | Max simultaneous downloads when using a list                             |
+| `-h, --help`          | Display usage information                                                |
 
-You must provide either a URL or both a name and author.
+You must provide either a collection URL, a game URL, or both a name and author.
 
 You can set the API key in an `.env` file or environment variable `ITCH_API_KEY`
 so the `--apiKey` flag is optional.
@@ -48,6 +49,9 @@ itchio-downloader --name "manic miners" --author "baraklava"
 
 # Limiting concurrent downloads when using a list
 itchio-downloader --url "https://baraklava.itch.io/manic-miners" --concurrency 2
+
+# Downloading all games from a collection
+itchio-downloader --collection "https://itch.io/c/123/example"
 ```
 
 If you have the package installed locally without `-g`, run the examples with `npx itchio-downloader` or `pnpm dlx itchio-downloader`.

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -47,6 +47,7 @@ jest.mock('yargs', () => {
 });
 
 import * as downloadGameModule from '../itchDownloader/downloadGame';
+import * as downloadCollectionModule from '../itchDownloader/downloadCollection';
 import { run } from '../cli';
 
 describe('cli', () => {
@@ -220,7 +221,13 @@ describe('cli', () => {
       .mockResolvedValue('ok' as any);
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
 
-    await run(['node', 'cli.ts', '--url', 'https://author.itch.io/game', '--memory']);
+    await run([
+      'node',
+      'cli.ts',
+      '--url',
+      'https://author.itch.io/game',
+      '--memory',
+    ]);
 
     expect(mock).toHaveBeenCalledWith(
       {
@@ -233,6 +240,29 @@ describe('cli', () => {
       1,
     );
     expect(logSpy).toHaveBeenCalled();
+  });
+
+  it('handles collection option', async () => {
+    const mock = jest
+      .spyOn(downloadCollectionModule, 'downloadCollection')
+      .mockResolvedValue('col' as any);
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    await run([
+      'node',
+      'cli.ts',
+      '--collection',
+      'https://itch.io/c/1/test',
+      '--concurrency',
+      '2',
+    ]);
+
+    expect(mock).toHaveBeenCalledWith('https://itch.io/c/1/test', undefined, {
+      downloadDirectory: undefined,
+      concurrency: 2,
+      onProgress: undefined,
+    });
+    expect(logSpy).toHaveBeenCalledWith('Collection Download Result:', 'col');
   });
 
   it('exits when required arguments are missing', async () => {

--- a/src/itchDownloader/__tests__/downloadCollection.test.ts
+++ b/src/itchDownloader/__tests__/downloadCollection.test.ts
@@ -1,0 +1,59 @@
+import { downloadCollection } from '../downloadCollection';
+import * as downloadGameMod from '../downloadGame';
+
+describe('downloadCollection', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    (global.fetch as any)?.mockRestore?.();
+  });
+
+  it('fetches pages and downloads all game urls', async () => {
+    const fetchMock = jest.fn();
+    (global as any).fetch = fetchMock;
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          games: [{ url: 'https://a' }, { url: 'https://b' }],
+          next_page: 2,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ games: [{ url: 'https://c' }], next_page: null }),
+      });
+
+    const dgMock = jest
+      .spyOn(downloadGameMod, 'downloadGame')
+      .mockResolvedValue('done' as any);
+
+    const res = await downloadCollection('https://itch.io/c/123/test', 'key', {
+      downloadDirectory: '/tmp',
+      concurrency: 2,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(dgMock).toHaveBeenCalledWith(
+      [
+        { itchGameUrl: 'https://a', apiKey: 'key', downloadDirectory: '/tmp' },
+        { itchGameUrl: 'https://b', apiKey: 'key', downloadDirectory: '/tmp' },
+        { itchGameUrl: 'https://c', apiKey: 'key', downloadDirectory: '/tmp' },
+      ],
+      2,
+    );
+    expect(res).toBe('done');
+  });
+
+  it('omits apiKey when not provided', async () => {
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ games: [{ url: 'https://a' }], next_page: null }),
+    });
+    delete process.env.ITCH_API_KEY;
+    const dgMock = jest
+      .spyOn(downloadGameMod, 'downloadGame')
+      .mockResolvedValue('x' as any);
+    await downloadCollection('https://itch.io/c/1/test');
+    expect(dgMock).toHaveBeenCalledWith([{ itchGameUrl: 'https://a' }], 1);
+  });
+});

--- a/src/itchDownloader/downloadCollection.ts
+++ b/src/itchDownloader/downloadCollection.ts
@@ -1,0 +1,72 @@
+import { downloadGame } from './downloadGame';
+import {
+  DownloadGameParams,
+  DownloadGameResponse,
+  DownloadProgress,
+} from './types';
+
+function parseCollectionId(url: string): string {
+  const match = url.match(/\/c\/(\d+)/);
+  if (!match) throw new Error('Invalid collection url');
+  return match[1];
+}
+
+async function fetchGameUrls(
+  collectionId: string,
+  apiKey?: string,
+): Promise<string[]> {
+  const urls: string[] = [];
+  let page = 1;
+  while (true) {
+    const reqUrl = new URL(
+      `https://api.itch.io/collections/${collectionId}/collection-games`,
+    );
+    reqUrl.searchParams.set('page', String(page));
+    if (apiKey) reqUrl.searchParams.set('api_key', apiKey);
+    const res = await fetch(reqUrl.toString());
+    if (!res.ok) {
+      const err: any = new Error(
+        `Failed to fetch collection page ${page}: ${res.status}`,
+      );
+      err.statusCode = res.status;
+      throw err;
+    }
+    const data = await res.json();
+    if (Array.isArray(data.games)) {
+      for (const g of data.games) {
+        if (g && g.url) urls.push(g.url);
+      }
+    }
+    const nextRaw = data.next_page ?? data.next_page_url;
+    if (nextRaw === undefined || nextRaw === null) {
+      break;
+    }
+    const next = Number(nextRaw);
+    page = Number.isFinite(next) ? next : page + 1;
+  }
+  return urls;
+}
+
+export interface DownloadCollectionOptions {
+  downloadDirectory?: string;
+  concurrency?: number;
+  onProgress?: (info: DownloadProgress) => void;
+}
+
+export async function downloadCollection(
+  collectionUrl: string,
+  apiKey?: string,
+  opts: DownloadCollectionOptions = {},
+): Promise<DownloadGameResponse | DownloadGameResponse[]> {
+  const key = apiKey || process.env.ITCH_API_KEY;
+  const id = parseCollectionId(collectionUrl);
+  const gameUrls = await fetchGameUrls(id, key);
+  const params: DownloadGameParams[] = gameUrls.map((u) => {
+    const p: DownloadGameParams = { itchGameUrl: u };
+    if (opts.downloadDirectory) p.downloadDirectory = opts.downloadDirectory;
+    if (opts.onProgress) p.onProgress = opts.onProgress;
+    if (key) p.apiKey = key;
+    return p;
+  });
+  return downloadGame(params, opts.concurrency ?? 1);
+}

--- a/src/types/cli.ts
+++ b/src/types/cli.ts
@@ -1,5 +1,6 @@
 export interface CLIArgs {
   url?: string;
+  collection?: string;
   name?: string;
   author?: string;
   downloadDirectory?: string;


### PR DESCRIPTION
## Summary
- implement `downloadCollection` to fetch collection games and call `downloadGame`
- expose `--collection` flag in CLI
- document collection usage
- add unit tests for collection download and CLI flag

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_68735dd1978c83248f5240f56497b545